### PR TITLE
Apply performance fix for changelog indexing too

### DIFF
--- a/app/code/community/SomethingDigital/SearchPerf/Model/Index/Action/Fulltext/Refresh.php
+++ b/app/code/community/SomethingDigital/SearchPerf/Model/Index/Action/Fulltext/Refresh.php
@@ -2,19 +2,5 @@
 
 class SomethingDigital_SearchPerf_Model_Index_Action_Fulltext_Refresh extends Enterprise_CatalogSearch_Model_Index_Action_Fulltext_Refresh
 {
-    /**
-     * Reset search results
-     *
-     * We are writing this as adding this WHERE is a lot faster
-     *
-     * @return void
-     */
-    protected function _resetSearchResults()
-    {
-        $adapter = $this->_getWriteAdapter();
-        $adapter->update($this->_getTable('catalogsearch/search_query'), array('is_processed' => 0), array('is_processed != 0'));
-        $adapter->delete($this->_getTable('catalogsearch/result'));
-
-        $this->_app->dispatchEvent('enterprise_catalogsearch_reset_search_result', array());
-    }
+    use SomethingDigital_SearchPerf_Trait_ResetsSearchResults;
 }

--- a/app/code/community/SomethingDigital/SearchPerf/Model/Index/Action/Fulltext/Refresh/Changelog.php
+++ b/app/code/community/SomethingDigital/SearchPerf/Model/Index/Action/Fulltext/Refresh/Changelog.php
@@ -2,19 +2,5 @@
 
 class SomethingDigital_SearchPerf_Model_Index_Action_Fulltext_Refresh_Changelog extends Enterprise_CatalogSearch_Model_Index_Action_Fulltext_Refresh_Changelog
 {
-    /**
-     * Reset search results
-     *
-     * We are writing this as adding this WHERE is a lot faster
-     *
-     * @return void
-     */
-    protected function _resetSearchResults()
-    {
-        $adapter = $this->_getWriteAdapter();
-        $adapter->update($this->_getTable('catalogsearch/search_query'), array('is_processed' => 0), array('is_processed != 0'));
-        $adapter->delete($this->_getTable('catalogsearch/result'));
-
-        $this->_app->dispatchEvent('enterprise_catalogsearch_reset_search_result', array());
-    }
+    use SomethingDigital_SearchPerf_Trait_ResetsSearchResults;
 }

--- a/app/code/community/SomethingDigital/SearchPerf/Model/Index/Action/Fulltext/Refresh/Changelog.php
+++ b/app/code/community/SomethingDigital/SearchPerf/Model/Index/Action/Fulltext/Refresh/Changelog.php
@@ -1,6 +1,6 @@
 <?php
 
-class SomethingDigital_SearchPerf_Model_Index_Action_Fulltext_Refresh extends Enterprise_CatalogSearch_Model_Index_Action_Fulltext_Refresh
+class SomethingDigital_SearchPerf_Model_Index_Action_Fulltext_Refresh_Changelog extends Enterprise_CatalogSearch_Model_Index_Action_Fulltext_Refresh_Changelog
 {
     /**
      * Reset search results

--- a/app/code/community/SomethingDigital/SearchPerf/Model/Index/Action/Fulltext/Refresh/Row.php
+++ b/app/code/community/SomethingDigital/SearchPerf/Model/Index/Action/Fulltext/Refresh/Row.php
@@ -2,19 +2,5 @@
 
 class SomethingDigital_SearchPerf_Model_Index_Action_Fulltext_Refresh_Row extends Enterprise_CatalogSearch_Model_Index_Action_Fulltext_Refresh_Row
 {
-    /**
-     * Reset search results
-     *
-     * We are writing this as adding this WHERE is a lot faster
-     *
-     * @return void
-     */
-    protected function _resetSearchResults()
-    {
-        $adapter = $this->_getWriteAdapter();
-        $adapter->update($this->_getTable('catalogsearch/search_query'), array('is_processed' => 0), array('is_processed != 0'));
-        $adapter->delete($this->_getTable('catalogsearch/result'));
-
-        $this->_app->dispatchEvent('enterprise_catalogsearch_reset_search_result', array());
-    }
+    use SomethingDigital_SearchPerf_Trait_ResetsSearchResults;
 }

--- a/app/code/community/SomethingDigital/SearchPerf/Model/Index/Action/Fulltext/Refresh/Row.php
+++ b/app/code/community/SomethingDigital/SearchPerf/Model/Index/Action/Fulltext/Refresh/Row.php
@@ -1,6 +1,6 @@
 <?php
 
-class SomethingDigital_SearchPerf_Model_Index_Action_Fulltext_Refresh extends Enterprise_CatalogSearch_Model_Index_Action_Fulltext_Refresh
+class SomethingDigital_SearchPerf_Model_Index_Action_Fulltext_Refresh_Row extends Enterprise_CatalogSearch_Model_Index_Action_Fulltext_Refresh_Row
 {
     /**
      * Reset search results

--- a/app/code/community/SomethingDigital/SearchPerf/Trait/ResetsSearchResults.php
+++ b/app/code/community/SomethingDigital/SearchPerf/Trait/ResetsSearchResults.php
@@ -1,0 +1,38 @@
+<?php
+
+/**
+ * @property Mage_Core_Model_App $_app Application model.
+ */
+trait SomethingDigital_SearchPerf_Trait_ResetsSearchResults
+{
+    /**
+     * Reset search results
+     *
+     * We are rewriting this as adding this WHERE is a lot faster
+     *
+     * @return void
+     */
+    protected function _resetSearchResults()
+    {
+        $adapter = $this->_getWriteAdapter();
+        $adapter->update($this->_getTable('catalogsearch/search_query'), array('is_processed' => 0), array('is_processed != 0'));
+        $adapter->delete($this->_getTable('catalogsearch/result'));
+
+        $this->_app->dispatchEvent('enterprise_catalogsearch_reset_search_result', array());
+    }
+
+    /**
+     * Retrieve a write adapter to the database.
+     *
+     * @return Varien_Db_Adapter_Interface
+     */
+    abstract protected function _getWriteAdapter();
+
+    /**
+     * Proxy for resource getTable()
+     *
+     * @param string $entityName Alias to retrieve.
+     * @return string
+     */
+    abstract protected function _getTable($entityName);
+}

--- a/app/code/community/SomethingDigital/SearchPerf/etc/config.xml
+++ b/app/code/community/SomethingDigital/SearchPerf/etc/config.xml
@@ -10,6 +10,8 @@
             <enterprise_catalogsearch>
                 <rewrite>
                     <index_action_fulltext_refresh>SomethingDigital_SearchPerf_Model_Index_Action_Fulltext_Refresh</index_action_fulltext_refresh>
+                    <index_action_fulltext_refresh_changelog>SomethingDigital_SearchPerf_Model_Index_Action_Fulltext_Refresh_Changelog</index_action_fulltext_refresh_changelog>
+                    <index_action_fulltext_refresh_row>SomethingDigital_SearchPerf_Model_Index_Action_Fulltext_Refresh_Row</index_action_fulltext_refresh_row>
                 </rewrite>
             </enterprise_catalogsearch>
             <catalogsearch_resource>


### PR DESCRIPTION
This avoids a lock and slow query that can happen every minute.  I'd rather spend that MySQL CPU time on customers rather than on a bad query.

Seeing this run even on sites with Solr enabled.  I believe it still clears the cached results, even when indexing is done via Solr.
