### PR TITLE
Remove processed reset in latest Magento releases

### DIFF
--- a/app/code/community/SomethingDigital/SearchPerf/Model/Resource/Fulltext.php
+++ b/app/code/community/SomethingDigital/SearchPerf/Model/Resource/Fulltext.php
@@ -2,6 +2,8 @@
 
 class SomethingDigital_SearchPerf_Model_Resource_Fulltext extends Mage_CatalogSearch_Model_Resource_Fulltext
 {
+    use SomethingDigital_SearchPerf_Trait_ResetsSearchResults;
+
     /**
      * Reset search results
      *
@@ -13,10 +15,7 @@ class SomethingDigital_SearchPerf_Model_Resource_Fulltext extends Mage_CatalogSe
      */
     public function resetSearchResults()
     {
-        $adapter = $this->_getWriteAdapter();
-        $adapter->update($this->getTable('catalogsearch/search_query'), array('is_processed' => 0), array('is_processed != 0'));
-        $adapter->delete($this->getTable('catalogsearch/result'));
-
+        $this->_doResetQueries();
         Mage::dispatchEvent('catalogsearch_reset_search_result');
 
         return $this;

--- a/app/code/community/SomethingDigital/SearchPerf/Trait/ResetsSearchResults.php
+++ b/app/code/community/SomethingDigital/SearchPerf/Trait/ResetsSearchResults.php
@@ -14,11 +14,39 @@ trait SomethingDigital_SearchPerf_Trait_ResetsSearchResults
      */
     protected function _resetSearchResults()
     {
-        $adapter = $this->_getWriteAdapter();
-        $adapter->update($this->_getTable('catalogsearch/search_query'), array('is_processed' => 0), array('is_processed != 0'));
-        $adapter->delete($this->_getTable('catalogsearch/result'));
-
+        $this->_doResetQueries();
         $this->_app->dispatchEvent('enterprise_catalogsearch_reset_search_result', array());
+    }
+
+    /**
+     * Perform actual reset queries.
+     *
+     * @return void
+     */
+    protected function _doResetQueries()
+    {
+        if (!$this->shouldSkipResetQueries()) {
+            $adapter = $this->_getWriteAdapter();
+            $adapter->update($this->_getTable('catalogsearch/search_query'), array('is_processed' => 0), array('is_processed != 0'));
+            $adapter->delete($this->_getTable('catalogsearch/result'));
+        }
+    }
+
+    /**
+     * Check if we're using EE 1.14.3+ or CE 1.9.3+, where deleting is skipped.
+     *
+     * @return boolean
+     */
+    protected function shouldSkipResetQueries()
+    {
+        $version = Mage::getVersionInfo();
+        $skip = false;
+        if (Mage::getEdition() == Mage::EDITION_ENTERPRISE) {
+            $skip = $version['major'] >= 1 && $version['minor'] >= 14 && $version['revision'] >= 3;
+        } else {
+            $skip = $version['major'] >= 1 && $version['minor'] >= 9 && $version['revision'] >= 3;
+        }
+        return $skip;
     }
 
     /**


### PR DESCRIPTION
These were removed and it no longer handles the isProcessed flag exactly the same way.

Not sure if missing this could have any compatibility impact, it seems like it wouldn't break anything.  Still, if they're no longer required, should be faster to not do them.
